### PR TITLE
Add piece null check to SetupPieceInfo

### DIFF
--- a/Hygge/Patches/HudPatch.cs
+++ b/Hygge/Patches/HudPatch.cs
@@ -9,7 +9,7 @@ namespace Hygge.Patches {
     [HarmonyPostfix]
     [HarmonyPatch(nameof(Hud.SetupPieceInfo))]
     static void SetupPieceInfoPostfix(ref Hud __instance, Piece piece) {
-      if (!IsModEnabled.Value) {
+      if (!IsModEnabled.Value || piece == null) {
         return;
       }
 


### PR DESCRIPTION
Resolve a null reference issue when selecting an empty space in the build menu.