### PR TITLE
hygge: fix NRE occurring if selected piece is not available

### DIFF
--- a/Hygge/Patches/HudPatch.cs
+++ b/Hygge/Patches/HudPatch.cs
@@ -13,7 +13,7 @@ namespace Hygge.Patches {
         return;
       }
 
-      if (piece.m_comfort == 0) {
+      if (piece && piece.m_comfort == 0) {
         ComfortPanelManager.ToggleOff();
         return;
       }


### PR DESCRIPTION
If a piece was previously selected but is not available anymore for any reason, it will be `null` when passed down to `Hud.SetupPieceInfo`.

This could for example happen if using `Azumatt-SearchableBuildMenu` to filter build pieces after having selected a piece: if the piece is not available in the filtered list, then Hygge would spam the log with `NullReferenceException`.