### PR TITLE
Add Controller Support to ComfyGizmo

### DIFF
--- a/ComfyGizmo/Config/PluginConfig.cs
+++ b/ComfyGizmo/Config/PluginConfig.cs
@@ -34,6 +34,7 @@ public static class PluginConfig {
     SnapDivisions.OnSettingChanged(RotationManager.ResetRotationConditional);
 
     BindKeysConfig(config);
+    BindButtonsConfig(config);
     BindGizmoColorsConfig(config);
 
     ShowGizmoPrefab =
@@ -124,6 +125,16 @@ public static class PluginConfig {
   public static ConfigEntry<KeyboardShortcut> SelectTargetPieceKey { get; private set; }
   public static ConfigEntry<KeyboardShortcut> SnapDivisionIncrementKey { get; private set; }
   public static ConfigEntry<KeyboardShortcut> SnapDivisionDecrementKey { get; private set; }
+  
+  public static ConfigEntry<string> XRotationButton { get; private set; }
+  public static ConfigEntry<string> ZRotationButton { get; private set; }
+  public static ConfigEntry<string> ResetRotationButton { get; private set; }
+  public static ConfigEntry<string> ResetAllRotationButton { get; private set; }
+  public static ConfigEntry<string> ChangeRotationModeButton { get; private set; }
+  public static ConfigEntry<string> CopyPieceRotationButton { get; private set; }
+  public static ConfigEntry<string> SelectTargetPieceButton { get; private set; }
+  public static ConfigEntry<string> SnapDivisionIncrementButton { get; private set; }
+  public static ConfigEntry<string> SnapDivisionDecrementButton { get; private set; }
 
   public static void BindKeysConfig(ConfigFile config) {
     XRotationKey =
@@ -187,7 +198,72 @@ public static class PluginConfig {
             "Keys",
             "snapDivisionDecrement",
             new KeyboardShortcut(KeyCode.PageDown),
+            "Halves snap divisions from current.");
+  }
+  
+  public static void BindButtonsConfig(ConfigFile config) {
+    XRotationButton =
+        config.BindInOrder(
+            "Keys",
+            "xRotationButton",
+            "JoyDPadLeft",
+            "Hold this key to rotate on the x-axis/plane (red circle).");
+
+    ZRotationButton =
+        config.BindInOrder(
+            "Keys",
+            "zRotationButton",
+            "JoyDPadRight",
+            "Hold this key to rotate on the z-axis/plane (blue circle).");
+
+    ResetRotationButton =
+        config.BindInOrder(
+            "Keys",
+            "resetRotationButton",
+            "JoyButtonY",
+            "Press this key to reset the selected axis to zero rotation.");
+
+    ResetAllRotationButton =
+        config.BindInOrder(
+            "Keys",
+            "resetAllRotationButton",
+            "JoyButtonBack",
+            "Press this key to reset _all axis_ rotations to zero rotation.");
+
+    ChangeRotationModeButton =
+        config.BindInOrder(
+            "Keys",
+            "changeRotationModeButton",
+            "JoyButtonX",
+            "Press this key to toggle rotation modes.");
+
+    CopyPieceRotationButton =
+        config.BindInOrder(
+            "Keys",
+            "copyPieceRotationButton",
+            "JoyLBumper",
+            "Press this key to copy targeted piece's rotation.");
+
+    SelectTargetPieceButton =
+        config.BindInOrder(
+            "Keys",
+            "selectTargetPieceButton",
+            "JoyRStickDown",
+            "Selects target piece to be used.");
+
+    SnapDivisionIncrementButton =
+        config.BindInOrder(
+            "Keys",
+            "snapDivisionIncrementButton",
+            "JoyDPadUp",
             "Doubles snap divisions from current.");
+
+    SnapDivisionDecrementButton =
+        config.BindInOrder(
+            "Keys",
+            "snapDivisionDecrementButton",
+            "JoyDPadDown",
+            "Halves snap divisions from current.");
   }
 
   public static ConfigEntry<Color> XGizmoColor { get; private set; }

--- a/ComfyGizmo/Config/PluginConfig.cs
+++ b/ComfyGizmo/Config/PluginConfig.cs
@@ -248,7 +248,7 @@ public static class PluginConfig {
         config.BindInOrder(
             "Controller",
             "selectTargetPieceButton",
-            "JoyRStickDown",
+            "StickRButton",
             "Selects target piece to be used.");
 
     SnapDivisionIncrementButton =

--- a/ComfyGizmo/Config/PluginConfig.cs
+++ b/ComfyGizmo/Config/PluginConfig.cs
@@ -204,63 +204,63 @@ public static class PluginConfig {
   public static void BindButtonsConfig(ConfigFile config) {
     XRotationButton =
         config.BindInOrder(
-            "Keys",
+            "Controller",
             "xRotationButton",
             "JoyDPadLeft",
             "Hold this key to rotate on the x-axis/plane (red circle).");
 
     ZRotationButton =
         config.BindInOrder(
-            "Keys",
+            "Controller",
             "zRotationButton",
             "JoyDPadRight",
             "Hold this key to rotate on the z-axis/plane (blue circle).");
 
     ResetRotationButton =
         config.BindInOrder(
-            "Keys",
+            "Controller",
             "resetRotationButton",
             "JoyButtonY",
             "Press this key to reset the selected axis to zero rotation.");
 
     ResetAllRotationButton =
         config.BindInOrder(
-            "Keys",
+            "Controller",
             "resetAllRotationButton",
             "JoyButtonBack",
             "Press this key to reset _all axis_ rotations to zero rotation.");
 
     ChangeRotationModeButton =
         config.BindInOrder(
-            "Keys",
+            "Controller",
             "changeRotationModeButton",
             "JoyButtonX",
             "Press this key to toggle rotation modes.");
 
     CopyPieceRotationButton =
         config.BindInOrder(
-            "Keys",
+            "Controller",
             "copyPieceRotationButton",
             "JoyLBumper",
             "Press this key to copy targeted piece's rotation.");
 
     SelectTargetPieceButton =
         config.BindInOrder(
-            "Keys",
+            "Controller",
             "selectTargetPieceButton",
             "JoyRStickDown",
             "Selects target piece to be used.");
 
     SnapDivisionIncrementButton =
         config.BindInOrder(
-            "Keys",
+            "Controller",
             "snapDivisionIncrementButton",
             "JoyDPadUp",
             "Doubles snap divisions from current.");
 
     SnapDivisionDecrementButton =
         config.BindInOrder(
-            "Keys",
+            "Controller",
             "snapDivisionDecrementButton",
             "JoyDPadDown",
             "Halves snap divisions from current.");

--- a/ComfyGizmo/Patches/PlayerPatch.cs
+++ b/ComfyGizmo/Patches/PlayerPatch.cs
@@ -106,7 +106,7 @@ static class PlayerPatch {
   [HarmonyPrefix]
   [HarmonyPatch(nameof(Player.UpdatePlacementGhost))]
   static void UpdatePlacementGhostPrefix(Player __instance) {
-    if (ZInput.GetKeyDown(SelectTargetPieceKey.Value.MainKey) || ZInput.GetButton(SelectTargetPieceButton.Value) && HasValidTargetPiece(__instance)) {
+    if ((ZInput.GetKeyDown(SelectTargetPieceKey.Value.MainKey) || ZInput.GetButtonDown(SelectTargetPieceButton.Value)) && HasValidTargetPiece(__instance)) {
       HammerTableManager.SelectTargetPiece(__instance);
     }
   }


### PR DESCRIPTION
Resolves #25 and #34.  Changes use Valheim's control binding, so any controller that Valheim supports will also be supported by this update.

Notes:
- Adds a new config section "Controller".  Mostly a clone of the "Keys" section, but labelled "*Button" instead of "*Key" for separation.
- Respects the controller input layout setting in-game with respect to how vanilla handles rotation.